### PR TITLE
fix: flatten CSV n8n output

### DIFF
--- a/src/nodes/CsvJsonHtmltableConverter/CsvJsonHtmltableConverter.node.ts
+++ b/src/nodes/CsvJsonHtmltableConverter/CsvJsonHtmltableConverter.node.ts
@@ -451,20 +451,16 @@ export class CsvJsonHtmltableConverter implements INodeType {
 
         // For n8n Object, return the object directly
         if (targetFormat === 'n8nObject') {
-          if (sourceFormat === 'html' && Array.isArray(result) && result.length > 1) {
-            // For HTML tables with multiple rows, we need to return each row as a separate item
-            // without wrapping them in a 'data' property
+          if (Array.isArray(result)) {
+            // Spread array results so each entry becomes its own item
             for (const row of result) {
               returnData.push({
                 json: row as IDataObject,
               });
             }
           } else {
-            // For other cases, maintain existing behavior
-            // If result is an array with a single item, return just that item
-            const unwrappedResult = Array.isArray(result) && result.length === 1 ? result[0] : result;
             returnData.push({
-              json: unwrappedResult as IDataObject,
+              json: result as IDataObject,
             });
           }
         } else {


### PR DESCRIPTION
## Summary
- return array entries as individual items when converting to n8n object to avoid nested arrays

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config file)*
- `npm run build`
- `npm test` *(fails: Missing script: "test"*)

------
https://chatgpt.com/codex/tasks/task_b_68b6c6c9557c8320b258a68a03d84eb2