### PR TITLE
feat: merge inline styles

### DIFF
--- a/src/nodes/CsvJsonHtmltableConverter/utils/applyTableStyles.ts
+++ b/src/nodes/CsvJsonHtmltableConverter/utils/applyTableStyles.ts
@@ -22,6 +22,7 @@ function parseStyleString(style?: string): Record<string, string> {
 }
 
 function mergeStyles($el: cheerio.Cheerio, style?: string): void {
+  if (!style) return;
   const parsed = parseStyleString(style);
   if (Object.keys(parsed).length > 0) {
     $el.css(parsed);

--- a/src/nodes/CsvJsonHtmltableConverter/utils/applyTableStyles.ts
+++ b/src/nodes/CsvJsonHtmltableConverter/utils/applyTableStyles.ts
@@ -1,6 +1,29 @@
 import * as cheerio from 'cheerio';
 import type { ConversionOptions } from '../types';
 
+function parseStyleString(style?: string): Record<string, string> {
+  const styles: Record<string, string> = {};
+  if (!style) return styles;
+  style
+    .split(';')
+    .map((decl) => decl.trim())
+    .filter(Boolean)
+    .forEach((decl) => {
+      const [property, value] = decl.split(':');
+      if (property && value) {
+        styles[property.trim()] = value.trim();
+      }
+    });
+  return styles;
+}
+
+function mergeStyles($el: cheerio.Cheerio, style?: string): void {
+  const parsed = parseStyleString(style);
+  if (Object.keys(parsed).length > 0) {
+    $el.css(parsed);
+  }
+}
+
 /**
  * Applies custom styles to all tables in the provided HTML string according to the options.
  * @param htmlInput The HTML string containing one or more tables
@@ -20,60 +43,54 @@ export function applyTableStyles(htmlInput: string, options: ConversionOptions):
     if (options.tableClass) {
       $table.addClass(options.tableClass);
     }
-    if (options.tableStyle) {
-      $table.attr('style', options.tableStyle);
-    }
+    mergeStyles($table, options.tableStyle);
 
     // Border style for table (CSS)
     if (options.borderStyle) {
-      $table.attr('style', `${$table.attr('style') || ''}border-style: ${options.borderStyle};`);
+      $table.css('border-style', options.borderStyle);
     }
 
     // Border colour for table (CSS)
     if (options.borderColor) {
-      $table.attr('style', `${$table.attr('style') || ''}border-color: ${options.borderColor};`);
+      $table.css('border-color', options.borderColor);
     }
 
     // Border width for table (HTML attribute and CSS)
     if (typeof options.borderWidth === 'number' && options.borderWidth >= 0) {
       $table.attr('border', options.borderWidth.toString());
-      $table.attr('style', `${$table.attr('style') || ''}border-width: ${options.borderWidth}px;`);
+      $table.css('border-width', `${options.borderWidth}px`);
     }
 
     // Border radius for table (CSS)
     if (options.borderRadius) {
-      $table.attr('style', `${$table.attr('style') || ''}border-radius: ${options.borderRadius};`);
+      $table.css('border-radius', options.borderRadius);
     }
 
     // Border collapse for table (CSS)
     if (options.borderCollapse) {
-      $table.attr('style', `${$table.attr('style') || ''}border-collapse: ${options.borderCollapse};`);
+      $table.css('border-collapse', options.borderCollapse);
     }
 
     // Table text align (CSS)
     if (options.tableTextAlign) {
-      $table.attr('style', `${$table.attr('style') || ''}text-align: ${options.tableTextAlign};`);
+      $table.css('text-align', options.tableTextAlign);
     }
 
     // Row style and row text align
     $table.find('tr').each((i, row) => {
       const $row = $(row);
-      if (options.rowStyle) {
-        $row.attr('style', options.rowStyle);
-      }
+      mergeStyles($row, options.rowStyle);
       if (options.rowTextAlign) {
-        $row.attr('style', `${$row.attr('style') || ''}text-align: ${options.rowTextAlign};`);
+        $row.css('text-align', options.rowTextAlign);
       }
     });
 
     // Cell style and cell text align for <td> and <th>
     $table.find('td, th').each((_, cell) => {
       const $cell = $(cell);
-      if (options.cellStyle) {
-        $cell.attr('style', options.cellStyle);
-      }
+      mergeStyles($cell, options.cellStyle);
       if (options.cellTextAlign) {
-        $cell.attr('style', `${$cell.attr('style') || ''}text-align: ${options.cellTextAlign};`);
+        $cell.css('text-align', options.cellTextAlign);
       }
     });
 
@@ -92,13 +109,11 @@ export function applyTableStyles(htmlInput: string, options: ConversionOptions):
     // Caption style and position
     const $caption = $table.find('caption').first();
     if ($caption.length > 0) {
-      if (options.captionStyle) {
-        $caption.attr('style', options.captionStyle);
-      }
+      mergeStyles($caption, options.captionStyle);
       if (options.captionPosition === 'bottom') {
-        $caption.attr('style', `${$caption.attr('style') || ''}caption-side: bottom;`);
+        $caption.css('caption-side', 'bottom');
       } else if (options.captionPosition === 'top') {
-        $caption.attr('style', `${$caption.attr('style') || ''}caption-side: top;`);
+        $caption.css('caption-side', 'top');
       }
     }
   });

--- a/src/nodes/CsvJsonHtmltableConverter/utils/applyTableStyles.ts
+++ b/src/nodes/CsvJsonHtmltableConverter/utils/applyTableStyles.ts
@@ -90,7 +90,6 @@ export function applyTableStyles(htmlInput: string, options: ConversionOptions):
     $table.find('tr').each((i, row) => {
       const $row = $(row);
       mergeStyles($row, options.rowStyle);
-
       const rowStyles: Record<string, string> = {};
       if (options.rowTextAlign) {
         rowStyles['text-align'] = options.rowTextAlign;
@@ -104,7 +103,6 @@ export function applyTableStyles(htmlInput: string, options: ConversionOptions):
     $table.find('td, th').each((_, cell) => {
       const $cell = $(cell);
       mergeStyles($cell, options.cellStyle);
-
       const cellStyles: Record<string, string> = {};
       if (options.cellTextAlign) {
         cellStyles['text-align'] = options.cellTextAlign;
@@ -130,7 +128,6 @@ export function applyTableStyles(htmlInput: string, options: ConversionOptions):
     const $caption = $table.find('caption').first();
     if ($caption.length > 0) {
       mergeStyles($caption, options.captionStyle);
-
       const captionStyles: Record<string, string> = {};
       if (options.captionPosition === 'bottom') {
         captionStyles['caption-side'] = 'bottom';

--- a/src/nodes/CsvJsonHtmltableConverter/utils/applyTableStyles.ts
+++ b/src/nodes/CsvJsonHtmltableConverter/utils/applyTableStyles.ts
@@ -49,43 +49,54 @@ export function applyTableStyles(htmlInput: string, options: ConversionOptions):
     }
     mergeStyles($table, options.tableStyle);
 
+    const tableStyles: Record<string, string> = {};
+
     // Border style for table (CSS)
     if (options.borderStyle) {
-      $table.css('border-style', options.borderStyle);
+      tableStyles['border-style'] = options.borderStyle;
     }
 
     // Border colour for table (CSS)
     if (options.borderColor) {
-      $table.css('border-color', options.borderColor);
+      tableStyles['border-color'] = options.borderColor;
     }
 
     // Border width for table (HTML attribute and CSS)
     if (typeof options.borderWidth === 'number' && options.borderWidth >= 0) {
       $table.attr('border', options.borderWidth.toString());
-      $table.css('border-width', `${options.borderWidth}px`);
+      tableStyles['border-width'] = `${options.borderWidth}px`;
     }
 
     // Border radius for table (CSS)
     if (options.borderRadius) {
-      $table.css('border-radius', options.borderRadius);
+      tableStyles['border-radius'] = options.borderRadius;
     }
 
     // Border collapse for table (CSS)
     if (options.borderCollapse) {
-      $table.css('border-collapse', options.borderCollapse);
+      tableStyles['border-collapse'] = options.borderCollapse;
     }
 
     // Table text align (CSS)
     if (options.tableTextAlign) {
-      $table.css('text-align', options.tableTextAlign);
+      tableStyles['text-align'] = options.tableTextAlign;
+    }
+
+    if (Object.keys(tableStyles).length) {
+      $table.css(tableStyles);
     }
 
     // Row style and row text align
     $table.find('tr').each((i, row) => {
       const $row = $(row);
       mergeStyles($row, options.rowStyle);
+
+      const rowStyles: Record<string, string> = {};
       if (options.rowTextAlign) {
-        $row.css('text-align', options.rowTextAlign);
+        rowStyles['text-align'] = options.rowTextAlign;
+      }
+      if (Object.keys(rowStyles).length) {
+        $row.css(rowStyles);
       }
     });
 
@@ -93,8 +104,13 @@ export function applyTableStyles(htmlInput: string, options: ConversionOptions):
     $table.find('td, th').each((_, cell) => {
       const $cell = $(cell);
       mergeStyles($cell, options.cellStyle);
+
+      const cellStyles: Record<string, string> = {};
       if (options.cellTextAlign) {
-        $cell.css('text-align', options.cellTextAlign);
+        cellStyles['text-align'] = options.cellTextAlign;
+      }
+      if (Object.keys(cellStyles).length) {
+        $cell.css(cellStyles);
       }
     });
 
@@ -114,10 +130,15 @@ export function applyTableStyles(htmlInput: string, options: ConversionOptions):
     const $caption = $table.find('caption').first();
     if ($caption.length > 0) {
       mergeStyles($caption, options.captionStyle);
+
+      const captionStyles: Record<string, string> = {};
       if (options.captionPosition === 'bottom') {
-        $caption.css('caption-side', 'bottom');
+        captionStyles['caption-side'] = 'bottom';
       } else if (options.captionPosition === 'top') {
-        $caption.css('caption-side', 'top');
+        captionStyles['caption-side'] = 'top';
+      }
+      if (Object.keys(captionStyles).length) {
+        $caption.css(captionStyles);
       }
     }
   });

--- a/src/nodes/CsvJsonHtmltableConverter/utils/applyTableStyles.ts
+++ b/src/nodes/CsvJsonHtmltableConverter/utils/applyTableStyles.ts
@@ -9,9 +9,13 @@ function parseStyleString(style?: string): Record<string, string> {
     .map((decl) => decl.trim())
     .filter(Boolean)
     .forEach((decl) => {
-      const [property, value] = decl.split(':');
-      if (property && value) {
-        styles[property.trim()] = value.trim();
+      const colonIndex = decl.indexOf(':');
+      if (colonIndex !== -1) {
+        const property = decl.slice(0, colonIndex).trim();
+        const value = decl.slice(colonIndex + 1).trim();
+        if (property && value) {
+          styles[property] = value;
+        }
       }
     });
   return styles;


### PR DESCRIPTION
## Summary
- merge new style declarations with existing ones instead of overwriting
- use Cheerio's css() to apply individual properties safely

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: ESLint couldn't find an eslint.config.* file)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b6cd431490832091d5445a879003e5