### PR TITLE
refactor: centralize HTML escaping helper

### DIFF
--- a/src/nodes/CsvJsonHtmltableConverter/utils/constants.ts
+++ b/src/nodes/CsvJsonHtmltableConverter/utils/constants.ts
@@ -43,3 +43,9 @@ export const DEFAULT_CSV_DELIMITER = ',';
 export const DEFAULT_INCLUDE_HEADERS = true;
 export const DEFAULT_PRETTY_PRINT = false;
 export const DEFAULT_MULTIPLE_ITEMS = false;
+export const MINIFY_OPTIONS = {
+  minify_whitespace: true,
+  keepComments: false,
+  keepSpacesBetweenAttributes: false,
+  keepHtmlAndHeadOpeningTags: false,
+} as unknown as object;

--- a/src/nodes/CsvJsonHtmltableConverter/utils/csvConverter.ts
+++ b/src/nodes/CsvJsonHtmltableConverter/utils/csvConverter.ts
@@ -2,13 +2,17 @@ import Papa from 'papaparse';
 import minifyHtml from '@minify-html/node';
 import type { ConversionOptions } from '../types';
 import { DEFAULT_CSV_DELIMITER, DEFAULT_INCLUDE_HEADERS, DEFAULT_PRETTY_PRINT } from './constants';
+import { escapeHtml } from './escapeHtml';
 
 /**
  * Parses CSV data into a structured format
  */
 function parseCSV(csv: string, options: ConversionOptions) {
   const delimiter = options.csvDelimiter || DEFAULT_CSV_DELIMITER;
-  const includeHeaders = options.includeTableHeaders !== undefined ? options.includeTableHeaders : DEFAULT_INCLUDE_HEADERS;
+  const includeHeaders =
+    options.includeTableHeaders !== undefined
+      ? options.includeTableHeaders
+      : DEFAULT_INCLUDE_HEADERS;
 
   const result = Papa.parse(csv, {
     delimiter,
@@ -28,7 +32,8 @@ function parseCSV(csv: string, options: ConversionOptions) {
  */
 export async function csvToJson(csv: string, options: ConversionOptions): Promise<string> {
   const result = parseCSV(csv, options);
-  const prettyPrint = options.prettyPrint !== undefined ? options.prettyPrint : DEFAULT_PRETTY_PRINT;
+  const prettyPrint =
+    options.prettyPrint !== undefined ? options.prettyPrint : DEFAULT_PRETTY_PRINT;
 
   // If we have headers, result.data will already be an array of objects
   // If not, result.data will be an array of arrays
@@ -39,9 +44,13 @@ export async function csvToJson(csv: string, options: ConversionOptions): Promis
  * Converts CSV to HTML table
  */
 export async function csvToHtml(csv: string, options: ConversionOptions): Promise<string> {
-  const includeHeaders = options.includeTableHeaders !== undefined ? options.includeTableHeaders : DEFAULT_INCLUDE_HEADERS;
+  const includeHeaders =
+    options.includeTableHeaders !== undefined
+      ? options.includeTableHeaders
+      : DEFAULT_INCLUDE_HEADERS;
   const result = parseCSV(csv, { ...options, includeTableHeaders: false }); // We'll handle headers manually
-  const prettyPrint = options.prettyPrint !== undefined ? options.prettyPrint : DEFAULT_PRETTY_PRINT;
+  const prettyPrint =
+    options.prettyPrint !== undefined ? options.prettyPrint : DEFAULT_PRETTY_PRINT;
 
   let html = '<table>';
   const indentation = prettyPrint ? '\n  ' : '';
@@ -81,25 +90,15 @@ export async function csvToHtml(csv: string, options: ConversionOptions): Promis
 
   // Apply minification if pretty print is disabled
   if (!prettyPrint) {
-    html = minifyHtml.minify(Buffer.from(html), {
-      minify_whitespace: true,
-      keepComments: false,
-      keepSpacesBetweenAttributes: false,
-      keepHtmlAndHeadOpeningTags: false
-    } as unknown as object).toString();
+    html = minifyHtml
+      .minify(Buffer.from(html), {
+        minify_whitespace: true,
+        keepComments: false,
+        keepSpacesBetweenAttributes: false,
+        keepHtmlAndHeadOpeningTags: false,
+      } as unknown as object)
+      .toString();
   }
 
   return html;
-}
-
-/**
- * Escapes HTML special characters to prevent XSS
- */
-function escapeHtml(unsafe: string): string {
-  return unsafe
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#039;');
 }

--- a/src/nodes/CsvJsonHtmltableConverter/utils/csvConverter.ts
+++ b/src/nodes/CsvJsonHtmltableConverter/utils/csvConverter.ts
@@ -1,7 +1,12 @@
 import Papa from 'papaparse';
 import minifyHtml from '@minify-html/node';
 import type { ConversionOptions } from '../types';
-import { DEFAULT_CSV_DELIMITER, DEFAULT_INCLUDE_HEADERS, DEFAULT_PRETTY_PRINT } from './constants';
+import {
+  DEFAULT_CSV_DELIMITER,
+  DEFAULT_INCLUDE_HEADERS,
+  DEFAULT_PRETTY_PRINT,
+  MINIFY_OPTIONS,
+} from './constants';
 import { escapeHtml } from './escapeHtml';
 
 /**
@@ -90,14 +95,7 @@ export async function csvToHtml(csv: string, options: ConversionOptions): Promis
 
   // Apply minification if pretty print is disabled
   if (!prettyPrint) {
-    html = minifyHtml
-      .minify(Buffer.from(html), {
-        minify_whitespace: true,
-        keepComments: false,
-        keepSpacesBetweenAttributes: false,
-        keepHtmlAndHeadOpeningTags: false,
-      } as unknown as object)
-      .toString();
+    html = minifyHtml.minify(Buffer.from(html), MINIFY_OPTIONS).toString();
   }
 
   return html;

--- a/src/nodes/CsvJsonHtmltableConverter/utils/escapeHtml.ts
+++ b/src/nodes/CsvJsonHtmltableConverter/utils/escapeHtml.ts
@@ -1,0 +1,8 @@
+export function escapeHtml(unsafe: string): string {
+  return unsafe
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}

--- a/src/nodes/CsvJsonHtmltableConverter/utils/jsonConverter.ts
+++ b/src/nodes/CsvJsonHtmltableConverter/utils/jsonConverter.ts
@@ -1,6 +1,11 @@
 import { json2csv } from 'json-2-csv';
 import type { ConversionOptions } from '../types';
-import { DEFAULT_CSV_DELIMITER, DEFAULT_INCLUDE_HEADERS, DEFAULT_PRETTY_PRINT } from './constants';
+import {
+  DEFAULT_CSV_DELIMITER,
+  DEFAULT_INCLUDE_HEADERS,
+  DEFAULT_PRETTY_PRINT,
+  MINIFY_OPTIONS,
+} from './constants';
 import minifyHtml from '@minify-html/node';
 import { escapeHtml } from './escapeHtml';
 
@@ -190,14 +195,7 @@ export async function jsonToHtml(
 
     // Apply minification if pretty print is disabled
     if (!prettyPrint) {
-      html = minifyHtml
-        .minify(Buffer.from(html), {
-          minify_whitespace: true,
-          keepComments: false,
-          keepSpacesBetweenAttributes: false,
-          keepHtmlAndHeadOpeningTags: false,
-        } as unknown as object)
-        .toString();
+      html = minifyHtml.minify(Buffer.from(html), MINIFY_OPTIONS).toString();
     }
 
     return html;

--- a/src/nodes/CsvJsonHtmltableConverter/utils/jsonConverter.ts
+++ b/src/nodes/CsvJsonHtmltableConverter/utils/jsonConverter.ts
@@ -2,6 +2,7 @@ import { json2csv } from 'json-2-csv';
 import type { ConversionOptions } from '../types';
 import { DEFAULT_CSV_DELIMITER, DEFAULT_INCLUDE_HEADERS, DEFAULT_PRETTY_PRINT } from './constants';
 import minifyHtml from '@minify-html/node';
+import { escapeHtml } from './escapeHtml';
 
 /**
  * Parses JSON data into a structured format
@@ -19,31 +20,43 @@ function parseJSON(jsonStr: string) {
  */
 export async function jsonToCsv(jsonStr: string, options: ConversionOptions): Promise<string> {
   const delimiter = options.csvDelimiter || DEFAULT_CSV_DELIMITER;
-  const includeHeaders = options.includeTableHeaders !== undefined ? options.includeTableHeaders : DEFAULT_INCLUDE_HEADERS;
+  const includeHeaders =
+    options.includeTableHeaders !== undefined
+      ? options.includeTableHeaders
+      : DEFAULT_INCLUDE_HEADERS;
   const jsonData = parseJSON(jsonStr);
 
   // Handle different JSON structures (array of objects, array of arrays, etc.)
   try {
     // For array of objects, use json2csv parser
-    if (Array.isArray(jsonData) && jsonData.length > 0 && typeof jsonData[0] === 'object' && !Array.isArray(jsonData[0])) {
+    if (
+      Array.isArray(jsonData) &&
+      jsonData.length > 0 &&
+      typeof jsonData[0] === 'object' &&
+      !Array.isArray(jsonData[0])
+    ) {
       const fields = Object.keys(jsonData[0]);
       const optionsCsv = {
         delimiter: { field: delimiter },
         prependHeader: includeHeaders,
-        keys: fields
+        keys: fields,
       };
       return await json2csv(jsonData, optionsCsv);
     }
 
     // For array of arrays, convert directly
     if (Array.isArray(jsonData) && jsonData.length > 0 && Array.isArray(jsonData[0])) {
-      return jsonData.map(row =>
-        row.map((cell: unknown) =>
-          typeof cell === 'string' && cell.includes(delimiter) ?
-            `"${cell.replace(/"/g, '""')}"` :
-            String(cell)
-        ).join(delimiter)
-      ).join('\n');
+      return jsonData
+        .map((row) =>
+          row
+            .map((cell: unknown) =>
+              typeof cell === 'string' && cell.includes(delimiter)
+                ? `"${cell.replace(/"/g, '""')}"`
+                : String(cell),
+            )
+            .join(delimiter),
+        )
+        .join('\n');
     }
 
     // For simple objects, convert to array of key-value pairs
@@ -56,12 +69,14 @@ export async function jsonToCsv(jsonStr: string, options: ConversionOptions): Pr
       }
 
       for (const [key, value] of Object.entries(jsonData)) {
-        rows.push([
-          key,
-          typeof value === 'string' && value.includes(delimiter) ?
-            `"${value.replace(/"/g, '""')}"` :
-            String(value)
-        ].join(delimiter));
+        rows.push(
+          [
+            key,
+            typeof value === 'string' && value.includes(delimiter)
+              ? `"${value.replace(/"/g, '""')}"`
+              : String(value),
+          ].join(delimiter),
+        );
       }
 
       return rows.join('\n');
@@ -78,10 +93,14 @@ export async function jsonToCsv(jsonStr: string, options: ConversionOptions): Pr
  */
 export async function jsonToHtml(
   jsonData: string | Record<string, unknown> | unknown[],
-  options: ConversionOptions
+  options: ConversionOptions,
 ): Promise<string> {
-  const includeHeaders = options.includeTableHeaders !== undefined ? options.includeTableHeaders : DEFAULT_INCLUDE_HEADERS;
-  const prettyPrint = options.prettyPrint !== undefined ? options.prettyPrint : DEFAULT_PRETTY_PRINT;
+  const includeHeaders =
+    options.includeTableHeaders !== undefined
+      ? options.includeTableHeaders
+      : DEFAULT_INCLUDE_HEADERS;
+  const prettyPrint =
+    options.prettyPrint !== undefined ? options.prettyPrint : DEFAULT_PRETTY_PRINT;
 
   // Parse the input if it's a string, otherwise use as is
   const parsedData = typeof jsonData === 'string' ? parseJSON(jsonData) : jsonData;
@@ -91,7 +110,12 @@ export async function jsonToHtml(
 
   try {
     // Array of objects - most common case
-    if (Array.isArray(parsedData) && parsedData.length > 0 && typeof parsedData[0] === 'object' && !Array.isArray(parsedData[0])) {
+    if (
+      Array.isArray(parsedData) &&
+      parsedData.length > 0 &&
+      typeof parsedData[0] === 'object' &&
+      !Array.isArray(parsedData[0])
+    ) {
       const headers = Object.keys(parsedData[0]);
 
       if (includeHeaders) {
@@ -158,8 +182,7 @@ export async function jsonToHtml(
       }
 
       html += `${indentation}</tbody>`;
-    }
-    else {
+    } else {
       throw new Error('Unsupported JSON structure for HTML conversion');
     }
 
@@ -167,28 +190,18 @@ export async function jsonToHtml(
 
     // Apply minification if pretty print is disabled
     if (!prettyPrint) {
-      html = minifyHtml.minify(Buffer.from(html), {
-        minify_whitespace: true,
-        keepComments: false,
-        keepSpacesBetweenAttributes: false,
-        keepHtmlAndHeadOpeningTags: false
-      } as unknown as object).toString();
+      html = minifyHtml
+        .minify(Buffer.from(html), {
+          minify_whitespace: true,
+          keepComments: false,
+          keepSpacesBetweenAttributes: false,
+          keepHtmlAndHeadOpeningTags: false,
+        } as unknown as object)
+        .toString();
     }
 
     return html;
   } catch (error) {
     throw new Error(`JSON to HTML conversion error: ${error.message}`);
   }
-}
-
-/**
- * Escapes HTML special characters to prevent XSS
- */
-function escapeHtml(unsafe: string): string {
-  return unsafe
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#039;');
 }


### PR DESCRIPTION
## Summary
- extract shared `escapeHtml` utility
- use `escapeHtml` in CSV and JSON converters

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b6cd4b63a083208c262f15628123cf