### PR TITLE
Add Claude skill-pack for n8n JSON→UI workflow editing

### DIFF
--- a/claude-n8n-ui-skill/README.md
+++ b/claude-n8n-ui-skill/README.md
@@ -1,0 +1,60 @@
+# Claude Skill Pack for n8n Workflow Editing via UI (JSON-In, UI-Steps-Out)
+
+This directory repackages this repository for your target use case:
+
+- You paste **n8n workflow JSON** into Claude (Web or Desktop).
+- You ask for a change.
+- Claude returns **implementation instructions for n8n Web UI** (not raw JSON patching unless requested).
+
+## Why this structure
+
+The structure below is optimized for prompt consistency, repeatability, and easy reuse across Claude surfaces:
+
+```text
+claude-n8n-ui-skill/
+├─ README.md
+├─ skill/
+│  └─ SKILL.md
+├─ templates/
+│  ├─ request-template.md
+│  ├─ response-template.md
+│  └─ ui-change-checklist.md
+├─ examples/
+│  ├─ sample-user-request.md
+│  └─ sample-assistant-response.md
+└─ research/
+   └─ references.md
+```
+
+## Implementation (Claude Web)
+
+1. Create a dedicated Claude Project (e.g., `n8n Workflow Builder`).
+2. Add the following files as project knowledge:
+   - `skill/SKILL.md`
+   - `templates/response-template.md`
+   - `templates/ui-change-checklist.md`
+3. Pin a Project instruction derived from `templates/request-template.md` (or paste it each session).
+4. When working: paste the workflow JSON + change request.
+5. Ask Claude to answer strictly in the response format from `templates/response-template.md`.
+
+## Implementation (Claude Desktop)
+
+1. Keep this directory locally and open the files as reference context when composing prompts.
+2. Start each thread by pasting:
+   - `skill/SKILL.md` (or a shortened version),
+   - your workflow JSON,
+   - and your change goal.
+3. Reuse `templates/request-template.md` to avoid drift.
+4. Verify output with `templates/ui-change-checklist.md` before applying changes in n8n UI.
+
+## Recommended operating pattern
+
+- **Source of truth:** workflow JSON from n8n export.
+- **Execution medium:** n8n UI click-steps.
+- **Validation:** run node-level test executions in n8n after each change block.
+- **Safety:** ask Claude for rollback instructions before implementing high-impact edits.
+
+## Notes
+
+- This repo originally contains an n8n community node codebase. This folder adds a dedicated, portable skill layer for your Claude-assisted workflow editing process.
+- External reference links used for design choices are listed in `research/references.md`.

--- a/claude-n8n-ui-skill/examples/sample-assistant-response.md
+++ b/claude-n8n-ui-skill/examples/sample-assistant-response.md
@@ -1,0 +1,32 @@
+## 1) Change summary
+- Objective: prevent records without an email from reaching HubSpot create/update node.
+- Scope: add one IF node and reroute one branch.
+- Risk level: Low.
+
+## 2) Impact map
+- Affected nodes: `Normalize Contact`, `HubSpot Upsert`.
+- Connection changes: insert `IF: Has Email` between these nodes.
+- Expression changes: condition uses `{{$json.email}}` existence check.
+
+## 3) n8n UI steps (ordered)
+1. Duplicate workflow as `...-backup`.
+2. Add an **IF** node named `Has Email` after `Normalize Contact`.
+3. In IF node, add condition: String `{{$json.email}}` "is not empty".
+4. Connect `Normalize Contact` → `Has Email`.
+5. Connect `Has Email` **true** output → `HubSpot Upsert`.
+6. Connect `Has Email` **false** output → `Missing Email Log` (or temporary NoOp).
+
+Expected result checkpoint:
+- Records with email flow to HubSpot; missing-email records are diverted.
+
+## 4) Expression updates (old → new)
+- No existing expression modified; new condition added in `Has Email`.
+
+## 5) Validation checklist
+- Execute `Normalize Contact` with one valid + one missing-email item.
+- Execute `Has Email`; confirm split across true/false outputs.
+- Execute from trigger; confirm HubSpot only receives valid records.
+
+## 6) Rollback plan
+- Remove `Has Email` node and restore original direct connection.
+- Or reactivate backup workflow copy.

--- a/claude-n8n-ui-skill/examples/sample-user-request.md
+++ b/claude-n8n-ui-skill/examples/sample-user-request.md
@@ -1,0 +1,4 @@
+Goal: Add validation so records missing email are filtered out before sending to HubSpot.
+Constraint: Do not change existing credentials or trigger node.
+
+<workflow json pasted here>

--- a/claude-n8n-ui-skill/research/references.md
+++ b/claude-n8n-ui-skill/research/references.md
@@ -1,0 +1,34 @@
+# Research log and design basis
+
+This skill-pack structure was designed from publicly available documentation that could be fetched from this environment.
+
+## Sources reviewed
+
+1. n8n Docs repository root (scope and maintenance context):
+   - https://raw.githubusercontent.com/n8n-io/n8n-docs/main/README.md
+2. n8n workflow export/import behavior:
+   - https://raw.githubusercontent.com/n8n-io/n8n-docs/main/docs/workflows/export-import.md
+   - Key finding: workflows are saved in JSON and can be imported/exported via Editor UI.
+3. n8n workflow creation/execution/publish lifecycle:
+   - https://raw.githubusercontent.com/n8n-io/n8n-docs/main/docs/workflows/create.md
+   - Key finding: build on canvas, execute manually during testing, publish for automatic runs.
+4. n8n expression model:
+   - https://raw.githubusercontent.com/n8n-io/n8n-docs/main/docs/code/expressions.md
+   - Key finding: expression syntax (`{{ ... }}`), variable selector, and dynamic parameter mapping are central.
+5. n8n data mapping concept:
+   - https://raw.githubusercontent.com/n8n-io/n8n-docs/main/docs/data/data-mapping/index.md
+   - Key finding: mapping prior-node data is a core workflow editing task.
+6. Anthropic Claude Code repository README (prompt/workflow discipline inspiration):
+   - https://raw.githubusercontent.com/anthropics/claude-code/main/README.md
+   - Key finding: strong emphasis on reusable command structures and repo-local guidance files.
+
+## Environment limitations encountered
+
+- Direct fetches from some docs websites (for example `docs.n8n.io` and some Anthropic-hosted web pages) returned HTTP 403 or empty responses in this execution environment.
+- To ensure accuracy despite that limitation, this plan relies on official source-of-truth markdown from public GitHub repositories wherever possible.
+
+## Resulting design decisions
+
+- Built a **JSON-in/UI-steps-out** skill with strict response schema.
+- Added reusable templates to reduce prompt drift between Claude Web and Claude Desktop sessions.
+- Added a user-side operational checklist for safe rollout and rollback in n8n UI.

--- a/claude-n8n-ui-skill/skill/SKILL.md
+++ b/claude-n8n-ui-skill/skill/SKILL.md
@@ -1,0 +1,44 @@
+# SKILL: n8n JSON Analysis → n8n UI Change Instructions
+
+## Purpose
+Transform user-supplied n8n workflow JSON into precise, low-risk instructions that the user implements manually in the n8n editor UI.
+
+## Operating constraints
+1. Treat workflow JSON as read-first context; do not assume hidden nodes or credentials.
+2. Prefer incremental UI edits over full rebuild guidance.
+3. Provide node-by-node instructions using visible labels and menu paths.
+4. Always include validation steps after each major change.
+5. Explicitly flag uncertainty when JSON lacks enough detail.
+
+## Input contract
+User should provide:
+- Workflow JSON (full preferred; partial accepted with caveats)
+- Goal statement (what should change)
+- Optional constraints (no new nodes, preserve IDs, keep credential names, etc.)
+
+## Output contract
+Always structure the response as:
+1. **Change summary**
+2. **Impact map** (affected nodes, connections, expressions)
+3. **n8n UI steps** (ordered, click-by-click)
+4. **Expression updates** (old → new)
+5. **Validation checklist**
+6. **Rollback plan**
+
+## n8n-specific guidance
+- Refer to nodes by `name` from JSON and include type when helpful.
+- For connection changes, mention both source and destination node names.
+- For expressions, preserve `{{$...}}` syntax and mention test data assumptions.
+- If credentials are involved, never invent secrets; instruct user where to select existing credentials.
+- For branching logic (`IF`, `Switch`, merge paths), describe expected execution paths with sample payloads.
+
+## Safety checks before final answer
+- No destructive step without backup/export reminder.
+- No credential value fabrication.
+- No instruction that depends on non-existent nodes unless creation is explicitly included.
+- No silent schema assumptions.
+
+## Preferred response style
+- Use concise numbered steps.
+- Keep one action per step.
+- Include "Expected result" checkpoints every 3–5 steps.

--- a/claude-n8n-ui-skill/templates/request-template.md
+++ b/claude-n8n-ui-skill/templates/request-template.md
@@ -1,0 +1,25 @@
+# Request Template (copy into Claude)
+
+You are helping me edit an n8n workflow via the n8n web UI.
+I will provide workflow JSON and I want UI implementation steps, not only JSON edits.
+
+## Goal
+<describe desired change>
+
+## Constraints
+- <example: do not change existing node IDs>
+- <example: preserve current credentials>
+- <example: add minimum number of nodes>
+
+## Workflow JSON
+```json
+<paste workflow json>
+```
+
+## Required response format
+1. Change summary
+2. Impact map (nodes, connections, expressions)
+3. Ordered n8n UI steps (click-by-click)
+4. Expression updates (old -> new)
+5. Validation checklist (node-level tests)
+6. Rollback plan

--- a/claude-n8n-ui-skill/templates/response-template.md
+++ b/claude-n8n-ui-skill/templates/response-template.md
@@ -1,0 +1,36 @@
+# Response Template (assistant should follow)
+
+## 1) Change summary
+- Objective:
+- Scope:
+- Risk level: Low / Medium / High
+
+## 2) Impact map
+- Affected nodes:
+- Connection changes:
+- Expression/parameter changes:
+- Data-shape assumptions:
+
+## 3) n8n UI steps (ordered)
+1. Open workflow `<workflow_name>` and duplicate it for backup.
+2. Select node `<node_name>`.
+3. In panel `<section>`, set `<field>` to `<value>`.
+4. ...
+
+**Expected result checkpoint:**
+- ...
+
+## 4) Expression updates (old → new)
+- Node `<node_name>`, field `<field>`:
+  - Old: `...`
+  - New: `...`
+
+## 5) Validation checklist
+- Execute node `<node_name>` with sample data `<sample>`.
+- Confirm output field `<field>` equals `<expected>`.
+- Run end-to-end test and verify `<condition>`.
+
+## 6) Rollback plan
+- Revert to duplicated backup workflow.
+- Or undo specific edits in reverse order:
+  1. ...

--- a/claude-n8n-ui-skill/templates/ui-change-checklist.md
+++ b/claude-n8n-ui-skill/templates/ui-change-checklist.md
@@ -1,0 +1,22 @@
+# UI Change Checklist (for user)
+
+## Before editing
+- [ ] Export current workflow JSON backup.
+- [ ] Confirm required credentials already exist in environment.
+- [ ] Confirm target workflow version/branch.
+
+## During editing
+- [ ] Apply changes in small batches (1 logical block at a time).
+- [ ] Run node-level execution after each batch.
+- [ ] Verify expression previews resolve without errors.
+- [ ] Verify connection lines match intended routing.
+
+## Before activation
+- [ ] Run at least one realistic end-to-end test execution.
+- [ ] Check error workflow path/notifications still work.
+- [ ] Re-check trigger settings (schedule/webhook/event).
+- [ ] Save and re-open workflow to ensure persistence.
+
+## After activation
+- [ ] Monitor first production runs.
+- [ ] Keep rollback workflow copy until stable window passes.


### PR DESCRIPTION
### Motivation
- Provide a reusable Claude-oriented skill that converts pasted n8n workflow JSON into precise, low-risk, click-by-click n8n Web UI instructions so users can implement changes via the UI instead of editing JSON directly. 
- Make interactions repeatable across Claude Web and Claude Desktop by bundling a `SKILL.md`, templates, examples and a research log to standardize prompts and expected assistant output. 
- Emphasize safety: the skill enforces non-destructive workflows, validation steps, and an explicit rollback checklist to reduce human error during manual UI edits. 

### Description
- Added a new `claude-n8n-ui-skill/` directory containing `README.md`, `skill/SKILL.md`, `templates/request-template.md`, `templates/response-template.md`, `templates/ui-change-checklist.md`, `examples/sample-user-request.md`, `examples/sample-assistant-response.md`, and `research/references.md` to implement the JSON-in → UI-steps-out workflow. 
- `SKILL.md` defines the input/output contract, operating constraints (treat JSON as read-first, prefer incremental UI edits), and required response structure (change summary, impact map, UI steps, expression updates, validation checklist, rollback plan). 
- Templates enforce consistent request/response formats and provide a user-facing UI change checklist; examples demonstrate a representative user request and the expected assistant response (node-level UI steps). 
- No runtime code or node implementation files were modified; this is a documentation/skill-pack addition only. 

### Testing
- Ran `npm test -- --runInBand`; the repository test run completed but reported pre-existing failures unrelated to these docs changes: `Test Suites: 1 failed, 8 passed, 9 total` and `Tests: 6 failed, 128 passed, 134 total` (failures are in `tests/conversion.test.ts` and concern heading-detection expectations). 
- Re-ran the failing suite with `npx jest tests/conversion.test.ts --runInBand --silent` to confirm the failures reproduce (same heading-detection failures). 
- Because the change is documentation/skill-pack only, no unit tests were added; recommend running `npm test` in CI and manual verification of the skill files when used in Claude Web/Desktop.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698ef68f953c83208af7dc040e81f652)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds documentation-only “skill pack” files with no runtime code changes, so impact is limited to developer/user guidance and prompt consistency.
> 
> **Overview**
> Adds a new `claude-n8n-ui-skill/` documentation bundle to standardize a **JSON-in → UI-steps-out** workflow for Claude-assisted n8n editing.
> 
> Includes `SKILL.md` defining operating constraints and a required response schema, reusable request/response templates plus a user checklist for safe UI edits (validation + rollback), and sample request/response + a references log to support repeatable prompting across Claude Web/Desktop.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit faf53ee813d0a90f00059927c34d6711f0b3d6f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->